### PR TITLE
Update restrictBoundaryEditing.js

### DIFF
--- a/restrictBoundaryEditing.js
+++ b/restrictBoundaryEditing.js
@@ -8,7 +8,8 @@ function canEdit(user, featureGeo) {
     var fsIntersectedBoundaries = Intersects(fsBoundary, featureGeo )
     //if no boundary error
     if (Count(fsIntersectedBoundaries) == 0)
-    return {"errorMessage": "Features must be created within a boundary"} 
+    return {"errorMessage": "Features must be created within a boundary"
+            "success": false};
     
     //we are interested in the first boundary
     //we can enhnace the script to look for all boundaries


### PR DESCRIPTION
Line 12 was added for success keyword. Without this keyword ArcGIS Pro 3.X will no longer validate the script upon saving it. 